### PR TITLE
Add support for 532d via 53xd

### DIFF
--- a/data/autosuspend.hwdb
+++ b/data/autosuspend.hwdb
@@ -176,6 +176,9 @@ usb:v27C6p521D*
 usb:v27C6p538D*
  ID_AUTOSUSPEND=1
 
+usb:v27C6p532D*
+ ID_AUTOSUSPEND=1
+
 # Supported by libfprint driver goodixtls511
 usb:v27c6p5110*
  ID_AUTOSUSPEND=1
@@ -319,7 +322,6 @@ usb:v27C6p5117*
 usb:v27C6p5201*
 usb:v27C6p5301*
 usb:v27C6p530C*
-usb:v27C6p532D*
 usb:v27C6p533C*
 usb:v27C6p5381*
 usb:v27C6p5385*

--- a/libfprint/drivers/goodixtls/goodix53xd.h
+++ b/libfprint/drivers/goodixtls/goodix53xd.h
@@ -63,6 +63,7 @@ guint8 goodix_53xd_config[] = {
 
 static const FpIdEntry id_table[] = {
     {.vid = 0x27c6, .pid = 0x538d},
+    {.vid = 0x27c6, .pid = 0x532d},
     {.vid = 0, .pid = 0, .driver_data = 0},
 };
 

--- a/libfprint/fprint-list-udev-hwdb.c
+++ b/libfprint/fprint-list-udev-hwdb.c
@@ -83,7 +83,6 @@ static const FpIdEntry whitelist_id_table[] = {
   { .vid = 0x27c6, .pid = 0x5201 },
   { .vid = 0x27c6, .pid = 0x5301 },
   { .vid = 0x27c6, .pid = 0x530c },
-  { .vid = 0x27c6, .pid = 0x532d },
   { .vid = 0x27c6, .pid = 0x533c },
   { .vid = 0x27c6, .pid = 0x5381 },
   { .vid = 0x27c6, .pid = 0x5385 },


### PR DESCRIPTION
I managed to get my `27c6:532d` Goodix reader working on Ubuntu with this change - no idea if this is the right branch to merge into or if it's no longer compatible with the latest `goodix_5xx` setup that's currently used in https://github.com/goodix-fp-linux-dev/libfprint/tree/goodixtls/libfprint/drivers/goodixtls, but hope this helps.

Thanks for writing the driver for 53xd!

![image](https://github.com/user-attachments/assets/270e1c92-6f96-43e4-99b8-ac4edd487973)
